### PR TITLE
fix: handle Urbanitae investmentPeriod given as a range

### DIFF
--- a/finanze/infrastructure/client/entity/financial/urbanitae/urbanitae_fetcher.py
+++ b/finanze/infrastructure/client/entity/financial/urbanitae/urbanitae_fetcher.py
@@ -91,7 +91,8 @@ class UrbanitaeFetcher(FinancialEntityFetcher):
             self._log.warning("No details found for project %s", project_id)
             return None
 
-        months = int(details["investmentPeriod"])
+        # investmentPeriod may be a single value or a range like "48-54"
+        months = max(int(p) for p in str(details["investmentPeriod"]).split("-"))
         interest_rate = Dezimal(
             fund_details.get("apreciationProfitability")
             or fund_details.get("totalNetProfitability")


### PR DESCRIPTION
Some Urbanitae projects return `investmentPeriod` as a range like `"48-54"`, making `_map_investment` raise `ValueError` on `int(...)` and abort the whole fetch. Take the upper bound of the range; single values are unaffected.

Closes #174