### PR TITLE
fix: IBKR transactions fetch

### DIFF
--- a/finanze/infrastructure/client/entity/financial/ibkr/ibkr_client.py
+++ b/finanze/infrastructure/client/entity/financial/ibkr/ibkr_client.py
@@ -49,6 +49,10 @@ _SERVER_MANAGED_COOKIES = {
 }
 
 
+class IBKRStatementError(Exception):
+    """Raised when an activity statement cannot be retrieved from IBKR."""
+
+
 def _parse_cookie_string(cookie_str: str) -> dict[str, str]:
     cookies = {}
     for pair in cookie_str.split("; "):
@@ -58,6 +62,20 @@ def _parse_cookie_string(cookie_str: str) -> dict[str, str]:
             if name and name not in cookies and name not in _SERVER_MANAGED_COOKIES:
                 cookies[name] = value.strip()
     return cookies
+
+
+def _is_json(resp: httpx.Response) -> bool:
+    return "json" in resp.headers.get("content-type", "")
+
+
+def _statement_error(resp: httpx.Response) -> Optional[str]:
+    # IBKR's own error for a period it cannot produce a statement for
+    if not _is_json(resp):
+        return None
+    try:
+        return resp.json().get("errors", {}).get("stmtError")
+    except ValueError:
+        return None
 
 
 class IBKRClient:
@@ -280,16 +298,11 @@ class IBKRClient:
                 return selection.get("id")
         return selections[0].get("id") if selections else None
 
-    async def download_activity_statement(self, from_date: date, to_date: date) -> str:
-        am_ready = await self._init_am_session()
-        if not am_ready:
-            self._log.error("Could not initialize AM session for statements")
-            return ""
+    async def _run_statement(self, from_str: str, to_str: str) -> httpx.Response:
+        if not await self._init_am_session():
+            raise IBKRStatementError("Could not initialize AM session for statements")
 
-        from_str = from_date.strftime("%Y%m%d")
-        to_str = to_date.strftime("%Y%m%d")
-
-        resp = await self._request(
+        return await self._request(
             "GET",
             "/AccountManagement/Statements/Run",
             headers=self._am_headers,
@@ -308,13 +321,42 @@ class IBKRClient:
                 "v2Modal": "true",
             },
         )
-        if not resp.is_success:
-            self._log.error(
-                "Failed to download activity statement: %d", resp.status_code
+
+    async def download_activity_statement(self, from_date: date, to_date: date) -> str:
+        from_str = from_date.strftime("%Y%m%d")
+        to_str = to_date.strftime("%Y%m%d")
+
+        resp = await self._run_statement(from_str, to_str)
+        if not _is_json(resp):
+            # Both the statement and IBKR's own errors come back as JSON, so
+            # anything else means the AM session went stale: rebuild and retry
+            self._log.warning(
+                "Unexpected statement response (%d, %s), retrying with a new AM session",
+                resp.status_code,
+                resp.headers.get("content-type", ""),
             )
+            self._am_headers = None
+            resp = await self._run_statement(from_str, to_str)
+
+        error = _statement_error(resp)
+        if error:
+            # No activity in that period, or a range the account cannot report on
+            self._log.info("No statement for %s-%s: %s", from_str, to_str, error)
             return ""
-        data = resp.json()
-        file_content = data.get("fileContent", "")
+
+        if not resp.is_success:
+            raise IBKRStatementError(
+                f"Statement request failed with status {resp.status_code}"
+            )
+
+        if not _is_json(resp):
+            self._log.error("Unexpected statement response body: %s", resp.text[:500])
+            raise IBKRStatementError("Statement request returned a non-JSON response")
+
+        file_content = resp.json().get("fileContent", "")
         if not file_content:
+            self._log.warning(
+                "Empty statement returned for range %s-%s", from_str, to_str
+            )
             return ""
         return base64.b64decode(file_content).decode("utf-8-sig")

--- a/finanze/infrastructure/client/entity/financial/ibkr/ibkr_client.py
+++ b/finanze/infrastructure/client/entity/financial/ibkr/ibkr_client.py
@@ -240,26 +240,45 @@ class IBKRClient:
             self._log.error("Could not find AM_SESSION_ID in AmAuthentication HTML")
             return False
 
-        am_session_id = match.group(1)
-        am_uuid = str(uuid.uuid4())
-        self._am_headers = {
-            "SessionId": am_session_id,
-            "AM_UUID": am_uuid,
+        am_headers = {
+            "SessionId": match.group(1),
+            "AM_UUID": str(uuid.uuid4()),
             "ACTIVE_CONTEXT": "AM_DEPENDENCY",
+            "Accept": "application/json, text/plain, */*",
         }
 
         resp = await self._request(
             "POST",
             "/AccountManagement/Statements/PageInfo",
             json={"action": "Statements"},
-            headers=self._am_headers,
+            headers=am_headers,
             timeout=AM_TIMEOUT,
         )
         if not resp.is_success:
             self._log.warning("AM PageInfo failed with status %d", resp.status_code)
             return False
 
+        # Statements are run against the account picked in the AM session, which
+        # is identified by a hash. Without it IBKR answers 200 with an empty body
+        account_hash = self._account_hash_from_page_info(resp)
+        if account_hash is None:
+            self._log.error("No account selection found in Statements PageInfo")
+            return False
+        am_headers["AccountHash"] = str(account_hash)
+
+        self._am_headers = am_headers
         return True
+
+    def _account_hash_from_page_info(self, resp: httpx.Response) -> Optional[int]:
+        try:
+            selections = resp.json().get("picker", {}).get("activeSelections", [])
+        except ValueError:
+            return None
+
+        for selection in selections:
+            if selection.get("accountId") == self._account_id:
+                return selection.get("id")
+        return selections[0].get("id") if selections else None
 
     async def download_activity_statement(self, from_date: date, to_date: date) -> str:
         am_ready = await self._init_am_session()

--- a/finanze/infrastructure/client/entity/financial/ibkr/ibkr_client.py
+++ b/finanze/infrastructure/client/entity/financial/ibkr/ibkr_client.py
@@ -19,6 +19,12 @@ from domain.native_entity import EntityCredentials
 BASE_URL = "https://www.interactivebrokers.ie"
 SESSION_LIFETIME = 50 * 60  # 50 minutes (IBKR sessions expire at ~54 min)
 
+DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+# Account Management pages are noticeably slower than the portal API
+AM_TIMEOUT = httpx.Timeout(60.0, connect=10.0)
+# Statements are generated on demand by IBKR and can take minutes to build
+STATEMENT_TIMEOUT = httpx.Timeout(180.0, connect=10.0)
+
 USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:148.0) "
     "Gecko/20100101 Firefox/148.0"
@@ -136,7 +142,15 @@ class IBKRClient:
         self._http = httpx.AsyncClient(
             cookies=cookies,
             headers=DEFAULT_HEADERS,
+            timeout=DEFAULT_TIMEOUT,
+            follow_redirects=True,
         )
+        self._am_headers = None
+
+    async def close(self) -> None:
+        if self._http:
+            await self._http.aclose()
+            self._http = None
         self._am_headers = None
 
     @staticmethod
@@ -214,6 +228,7 @@ class IBKRClient:
             "GET",
             "/AccountManagement/AmAuthentication",
             params={"action": "Statements"},
+            timeout=AM_TIMEOUT,
         )
         if not resp.is_success:
             self._log.warning("AM auth failed with status %d", resp.status_code)
@@ -238,6 +253,7 @@ class IBKRClient:
             "/AccountManagement/Statements/PageInfo",
             json={"action": "Statements"},
             headers=self._am_headers,
+            timeout=AM_TIMEOUT,
         )
         if not resp.is_success:
             self._log.warning("AM PageInfo failed with status %d", resp.status_code)
@@ -258,6 +274,7 @@ class IBKRClient:
             "GET",
             "/AccountManagement/Statements/Run",
             headers=self._am_headers,
+            timeout=STATEMENT_TIMEOUT,
             params={
                 "cashReportDetail": "TOTALS_WITH_SEGMENT_BREAKDOWN",
                 "format": "13",

--- a/finanze/infrastructure/client/entity/financial/ibkr/ibkr_fetcher.py
+++ b/finanze/infrastructure/client/entity/financial/ibkr/ibkr_fetcher.py
@@ -45,6 +45,9 @@ class IBKRFetcher(FinancialEntityFetcher):
             login_params.credentials, login_params.options, login_params.session
         )
 
+    async def close(self) -> None:
+        await self._client.close()
+
     async def global_position(self) -> GlobalPosition:
         account_id = self._client.account_id
         if not account_id:

--- a/finanze/infrastructure/client/entity/financial/ibkr/ibkr_fetcher.py
+++ b/finanze/infrastructure/client/entity/financial/ibkr/ibkr_fetcher.py
@@ -144,7 +144,8 @@ class IBKRFetcher(FinancialEntityFetcher):
     async def transactions(
         self, registered_txs: set[str], options: FetchOptions
     ) -> Transactions:
-        to_date = date.today()
+        # Statements only cover closed days, the current one is not reportable yet
+        to_date = date.today() - timedelta(days=1)
         all_isin_map: dict[str, str] = {}
         all_investment_txs: list[StockTx] = []
         all_account_txs: list[AccountTx] = []

--- a/tests/unit/infrastructure/client/financial/test_ibkr_client.py
+++ b/tests/unit/infrastructure/client/financial/test_ibkr_client.py
@@ -1,0 +1,167 @@
+import base64
+from datetime import date
+
+import httpx
+import pytest
+
+from infrastructure.client.entity.financial.ibkr.ibkr_client import (
+    IBKRClient,
+    IBKRStatementError,
+)
+
+FROM_DATE = date(2025, 1, 1)
+TO_DATE = date(2025, 12, 31)
+
+CSV_STATEMENT = (
+    "Statement,Header,Field Name,Field Value\r\n"
+    "Statement,Data,BrokerName,Interactive Brokers\r\n"
+)
+
+AM_HTML = "<html><script>var AM_SESSION_ID = 'am-session-1';</script></html>"
+ACCOUNT_ID = "U1234567"
+ACCOUNT_HASH = -310551676
+PAGE_INFO = {
+    "picker": {
+        "activeSelections": [
+            {"id": 42, "accountId": "U7654321"},
+            {"id": ACCOUNT_HASH, "accountId": ACCOUNT_ID},
+        ]
+    }
+}
+
+
+def _json_statement(csv_text: str = CSV_STATEMENT) -> dict:
+    return {"fileContent": base64.b64encode(csv_text.encode("utf-8")).decode()}
+
+
+class FakeIBKR:
+    """Serves canned responses for the Account Management statement flow."""
+
+    def __init__(
+        self, run_responses: list[httpx.Response], page_info: dict | None = None
+    ):
+        self._run_responses = run_responses
+        self._page_info = PAGE_INFO if page_info is None else page_info
+        self.run_calls = 0
+        self.am_auth_calls = 0
+        self.run_headers: list[httpx.Headers] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/AmAuthentication"):
+            self.am_auth_calls += 1
+            return httpx.Response(200, text=AM_HTML)
+        if path.endswith("/Statements/PageInfo"):
+            return httpx.Response(200, json=self._page_info)
+        if path.endswith("/Statements/Run"):
+            self.run_headers.append(request.headers)
+            resp = self._run_responses[
+                min(self.run_calls, len(self._run_responses) - 1)
+            ]
+            self.run_calls += 1
+            return resp
+        raise AssertionError(f"Unexpected request to {path}")
+
+
+def _client(fake: FakeIBKR) -> IBKRClient:
+    client = IBKRClient()
+    client._account_id = ACCOUNT_ID
+    client._http = httpx.AsyncClient(
+        transport=httpx.MockTransport(fake.handler),
+        base_url="https://www.interactivebrokers.ie",
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_download_activity_statement_decodes_json_envelope():
+    fake = FakeIBKR([httpx.Response(200, json=_json_statement())])
+
+    result = await _client(fake).download_activity_statement(FROM_DATE, TO_DATE)
+
+    assert result == CSV_STATEMENT
+    assert fake.run_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_download_activity_statement_retries_with_a_new_am_session():
+    fake = FakeIBKR(
+        [
+            httpx.Response(200, text="", headers={"content-type": "text/html"}),
+            httpx.Response(200, json=_json_statement()),
+        ]
+    )
+
+    result = await _client(fake).download_activity_statement(FROM_DATE, TO_DATE)
+
+    assert result == CSV_STATEMENT
+    assert fake.run_calls == 2
+    assert fake.am_auth_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_download_activity_statement_raises_on_non_json_response():
+    fake = FakeIBKR(
+        [httpx.Response(200, text="", headers={"content-type": "text/html"})]
+    )
+
+    with pytest.raises(IBKRStatementError):
+        await _client(fake).download_activity_statement(FROM_DATE, TO_DATE)
+
+    assert fake.run_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_download_activity_statement_raises_on_error_status():
+    fake = FakeIBKR([httpx.Response(500, text="boom")])
+
+    with pytest.raises(IBKRStatementError):
+        await _client(fake).download_activity_statement(FROM_DATE, TO_DATE)
+
+
+@pytest.mark.asyncio
+async def test_download_activity_statement_returns_empty_without_file_content():
+    fake = FakeIBKR([httpx.Response(200, json={"fileContent": ""})])
+
+    result = await _client(fake).download_activity_statement(FROM_DATE, TO_DATE)
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_statement_request_carries_the_picked_account_hash():
+    fake = FakeIBKR([httpx.Response(200, json=_json_statement())])
+
+    await _client(fake).download_activity_statement(FROM_DATE, TO_DATE)
+
+    assert fake.run_headers[0]["AccountHash"] == str(ACCOUNT_HASH)
+
+
+@pytest.mark.asyncio
+async def test_statement_fails_when_the_picker_has_no_account():
+    fake = FakeIBKR(
+        [httpx.Response(200, json=_json_statement())],
+        page_info={"picker": {"activeSelections": []}},
+    )
+
+    with pytest.raises(IBKRStatementError):
+        await _client(fake).download_activity_statement(FROM_DATE, TO_DATE)
+
+    assert fake.run_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_period_without_statement_is_not_an_error():
+    unavailable = {
+        "errors": {
+            "stmtError": "There is no statement available for the account(s) and date(s) selected."
+        }
+    }
+    fake = FakeIBKR([httpx.Response(601, json=unavailable)])
+
+    result = await _client(fake).download_activity_statement(FROM_DATE, TO_DATE)
+
+    assert result == ""
+    # IBKR gave a definitive answer, so there is nothing to retry
+    assert fake.run_calls == 1
+    assert fake.am_auth_calls == 1


### PR DESCRIPTION
## Misc
Fixes #179

Fetching transactions from Interactive Brokers always failed. Three causes, one per commit:

- **Timeouts.** `IBKRClient` never set one, so every request used httpx's 5s default. Account Management is slower than that, and generating a statement much more so. Explicit timeouts: 30s general, 60s for AM pages, 180s for statement generation. Also enables `follow_redirects`, and closes the HTTP client on `close()` (it was leaked on every fetch).
- **`AccountHash` header.** Without it IBKR answers `200` with an empty body, which is what made `resp.json()` blow up. It is taken from `picker.activeSelections` in the `Statements/PageInfo` response that was already being requested, matching the entry for the logged-in account. The AM session is now only cached once fully validated.
- **Periods without a statement.** IBKR answers `601` with `errors.stmtError` for a range it cannot report on, including a range ending today. The range now ends yesterday, and such a period is treated as empty instead of aborting the whole fetch. Previously a failure here also returned an empty string, which the fetcher read as "no more data", silently storing zero transactions and reporting success.

## Result
Verified against a live IBKR account: transactions now import (trades and interest) where the fetch previously failed every time. Added unit tests covering the statement download paths.

<img width="1512" height="982" alt="Captura de pantalla 2026-09-02 a las 19 55 22" src="https://github.com/user-attachments/assets/c0119e57-876c-4f07-a0c2-5918c070ba27" />
